### PR TITLE
Kpgw/bitbucket-ci

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -113,8 +113,8 @@ build/%/linux/install: %/linux.cfg build/%/linux.src build/%/linux/.config
 		&& make -j $$(( $$(nproc) - 1)) -C "build/$*/linux" -B \
 			ARCH=$${ARCH} \
 			CROSS_COMPILE=$${CROSS_COMPILE} \
-			INSTALL_PATH="/workspace/build/$*/linux/install/boot" \
-			INSTALL_MOD_PATH="/workspace/build/$*/linux/install" \
+			INSTALL_PATH="$$(pwd)/build/$*/linux/install/boot" \
+			INSTALL_MOD_PATH="$$(pwd)/build/$*/linux/install" \
 			$${INSTALL_TARGET:-install} \
 			modules_install \
 		&& for f in $${DTB}; do \

--- a/tools/git-clone
+++ b/tools/git-clone
@@ -30,7 +30,14 @@ if [ "$MAKROCOSM_GIT_CLONE_SHALLOW" = 1 ]; then
 	# git repo with the entire history. Shallow clone the repo.
 	echo "Shallow cloning from remote $URL into target $DEST_DIR" >&2
 	rm -rf "$DEST_DIR"
-	git clone --depth=1 --branch "$REFNAME" "$URL" "$DEST_DIR"
+	mkdir -p "$DEST_DIR"
+	git -C "$DEST_DIR" init && git -C "$DEST_DIR" remote add origin "$URL" && git -C "$DEST_DIR" fetch --depth 1 origin "$REFNAME" && git -C "$DEST_DIR" checkout FETCH_HEAD
+	for patch in $PATCHES; do
+		echo "Applying patch $patch" >&2
+		git -C "$DEST_DIR" am "$(pwd)/$patch" || patch -d "$DEST_DIR" -p1 -i "$(pwd)/$patch"
+	done
+
+	echo "git $URL $REFNAME $PATCHES" > "$DEST_DIR.src"
 	exit 0
 fi
 


### PR DESCRIPTION
Fixes for running in bitbucket ci (using their runners)

- Fix pathing for linux build when not building directly in a workspace container
- Use an alternate method for shallow clones so that plain git refs can be fetched